### PR TITLE
upgrade clojure-future-spec to 1.9.0-beta4

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
   [[org.clojure/clojure "1.8.0"]
    [org.clojure/core.cache "0.6.5"]
    [org.clojure/tools.logging "0.4.0"]
-   [clojure-future-spec "1.9.0-alpha14"]
+   [clojure-future-spec "1.9.0-beta4"]
    [byte-streams "0.2.3"]
    [mvxcvi/blocks "0.9.1"]
    [mvxcvi/clj-cbor "0.4.1"]

--- a/src/merkledag/link.clj
+++ b/src/merkledag/link.clj
@@ -4,7 +4,7 @@
   'reference size' value."
   (:require
     [clojure.future :refer [nat-int?]]
-    [clojure.spec :as s]
+    [clojure.spec.alpha :as s]
     [clojure.string :as str]
     [clojure.walk :as walk]
     [multihash.core :as multihash])

--- a/src/merkledag/node.clj
+++ b/src/merkledag/node.clj
@@ -2,7 +2,7 @@
   "Functions to serialize and operate on merkledag nodes."
   (:require
     [clojure.future :refer [pos-int?]]
-    [clojure.spec :as s]
+    [clojure.spec.alpha :as s]
     [merkledag.link :as link]
     [multihash.core :as multihash])
   (:import

--- a/test/merkledag/core_test.clj
+++ b/test/merkledag/core_test.clj
@@ -2,7 +2,7 @@
   (:require
     [blocks.core :as block]
     [blocks.store.memory :refer [memory-block-store]]
-    [clojure.spec :as s]
+    [clojure.spec.alpha :as s]
     [clojure.string :as str]
     [clojure.test :refer :all]
     [clojure.test.check.generators :as gen]


### PR DESCRIPTION
The main thing is to migrate from referring to the old clojure.spec namespace to the new
clojure.spec.alpha namespace.